### PR TITLE
Update CLI with actual real options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ A basic CLI is provided for compiling ActionScript files to SWF files.
 
 For full CLI usage, run `rascal --help`.
 
-There are two kinds of inputs, and they are intermixable. At least one entry point must be specified: either a script,
-or **one** class with a `static function main()` method.
+There are two kinds of inputs, and they are intermixable.
 
 - `rascal foo.as` - Compiles a script (not a class, loose code) into a SWF file.
     - Multiple script files can be specified, and they will execute in the order they are specified.
@@ -30,6 +29,7 @@ or **one** class with a `static function main()` method.
   into a SWF file.
     - The classpath defaults to working directory, but can be specified via the `--classpath` flag.
     - Multiple class names can be specified, and they will be loaded in the order they are specified.
+    - If one (and only one) class has a `static function main()`, it will be executed as the entry point to the swf.
 
 Various options about the output are available:
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,27 @@ A basic CLI is provided for compiling ActionScript files to SWF files.
 
 ### Usage
 
-For now, it's a simple `rascal filename.as` or `rascal filename.pcode`, and it will output `filename.swf`.
+For full CLI usage, run `rascal --help`.
 
-This definitely needs some love with more options - including multiple input files, SWF version, optimisation levels,
-etc.
+There are two kinds of inputs, and they are intermixable. At least one entry point must be specified: either a script,
+or **one** class with a `static function main()` method.
+
+- `rascal foo.as` - Compiles a script (not a class, loose code) into a SWF file.
+    - Multiple script files can be specified, and they will execute in the order they are specified.
+- `rascal -c some.ClassName` - Compiles a class named `some.ClassName` (expected to be available at `some/ClassName.as`)
+  into a SWF file.
+    - The classpath defaults to working directory, but can be specified via the `--classpath` flag.
+    - Multiple class names can be specified, and they will be loaded in the order they are specified.
+
+Various options about the output are available:
+
+- `-o foo.swf`/`--output foo.swf` - The output SWF file
+    - This defaults to either the first script file + `.swf`, else `output.swf`
+- `-v 10`/`--swf-version 10` - The version of SWF file to produce
+    - This defaults to 15,
+      which [corresponds to Flash Player 11.2](https://github.com/ruffle-rs/ruffle/wiki/SWF-version-chart)
+- `--frame-rate 30` - The frame rate of the SWF file
+    - This defaults to 24
 
 ## Library
 

--- a/crates/as2/src/error.rs
+++ b/crates/as2/src/error.rs
@@ -97,7 +97,7 @@ impl ErrorSet {
     }
 
     pub fn error_unless_empty(self) -> Result<(), Error> {
-        if self.io_errors.is_empty() && self.files.is_empty() {
+        if self.io_errors.is_empty() && self.files.is_empty() && self.misc_errors.is_empty() {
             return Ok(());
         }
         Err(Error(self))

--- a/crates/as2/src/program.rs
+++ b/crates/as2/src/program.rs
@@ -15,22 +15,41 @@ pub trait SourceProvider {
 }
 
 pub struct FileSystemSourceProvider {
-    root: PathBuf,
+    roots: Vec<PathBuf>,
 }
 
 impl FileSystemSourceProvider {
     pub fn with_root(root: PathBuf) -> Self {
-        Self { root }
+        Self::with_roots(vec![root])
+    }
+
+    pub fn with_roots(roots: Vec<PathBuf>) -> Self {
+        Self { roots }
     }
 }
 
 impl SourceProvider for FileSystemSourceProvider {
     fn load(&self, path: &str) -> Result<String, std::io::Error> {
-        std::fs::read_to_string(self.root.join(path))
+        for root in &self.roots {
+            let actual_path = root.join(path);
+            if actual_path.is_file() {
+                return std::fs::read_to_string(actual_path);
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "File not found",
+        ))
     }
 
     fn is_file(&self, path: &str) -> bool {
-        self.root.join(path).is_file()
+        for root in &self.roots {
+            let actual_path = root.join(path);
+            if actual_path.is_file() {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/crates/as2/src/program.rs
+++ b/crates/as2/src/program.rs
@@ -179,11 +179,7 @@ impl<P: SourceProvider> ProgramBuilder<P> {
         }
 
         match entry_point_class.len() {
-            0 => {
-                if initial_script.is_empty() {
-                    errors.add_misc_error("No entry point found (either 'static function main()' inside a class, or the initial file must be a script)".to_owned());
-                }
-            }
+            0 => {} // It's fine to have no entry point... even if it _may_ not entirely make sense :D
             1 => initial_script.push(call_main_method(entry_point_class.first().unwrap())),
             _ => errors.add_misc_error(format!(
                 "Conflicting entry points found on classes: {}",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,7 +4,7 @@ use rascal_as2::program::{FileSystemSourceProvider, ProgramBuilder};
 use rascal_as2_codegen::hir_to_pcode;
 use rascal_as2_pcode::pcode_to_swf;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(name = "rascal", version, author, about)]
@@ -38,6 +38,12 @@ struct Opt {
     #[arg(short, long)]
     class: Vec<String>,
 
+    /// Adds a directory to be searched for classes.
+    ///
+    /// If no classpaths are specified, the current working directory will be used instead.
+    #[arg(long, long)]
+    classpath: Vec<PathBuf>,
+
     /// SWF version to use.
     #[arg(short = 'v', long, default_value_t = 15)]
     swf_version: u8,
@@ -48,10 +54,12 @@ struct Opt {
 }
 
 fn main() -> Result<()> {
-    let opt = Opt::parse();
+    let mut opt = Opt::parse();
 
-    let root = Path::new(".");
-    let provider = FileSystemSourceProvider::with_root(root.to_owned());
+    if opt.classpath.is_empty() {
+        opt.classpath.push(PathBuf::from("."));
+    }
+    let provider = FileSystemSourceProvider::with_roots(opt.classpath);
     let mut builder = ProgramBuilder::new(provider);
 
     for src in &opt.script {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,15 +12,31 @@ struct Opt {
     /// A loose script (not class file) to add to the compiled program.
     ///
     /// Multiple scripts may be added to one program.
-    /// Scripts will be executed in order that they are added.
+    /// Scripts will be executed in order that they are added, before any classes are loaded.
+    ///
+    /// It is valid to not specify any scripts - if so, the entry point of the program will be the first
+    /// class (see `--class`) that contains a `static function main()` method.
     #[arg(name = "SCRIPT")]
     script: Vec<PathBuf>,
 
     /// Output file path. This will be overwritten if it already exists.
     ///
-    /// If not specified, the first script path (with ".swf" instead of ".as") will be used.
-    #[arg(short, long)]
+    /// If not specified:
+    /// - If there are any scripts (see `SCRIPT`) specified, the first one will be used to determine the output path.
+    /// - `output.swf` will be used if all else fails.
+    #[arg(short, long, verbatim_doc_comment)]
     output: Option<PathBuf>,
+
+    /// A name of a class to be added to the compiled program.
+    ///
+    /// This should be the canonical name of a class (e.g. `Foo` or `foo.bar.Baz`) which should be found in the current directory
+    /// (e.g. at `Foo.as` or `foo/bar/Baz.as`).
+    ///
+    /// All classes will be loaded after any scripts (see `SCRIPT`).
+    /// If no scripts are specified, one (and only one) class is expected to have an entry point in
+    /// the form of a `static function main()` method.
+    #[arg(short, long)]
+    class: Vec<String>,
 
     /// SWF version to use.
     #[arg(short = 'v', long, default_value_t = 15)]
@@ -34,21 +50,23 @@ struct Opt {
 fn main() -> Result<()> {
     let opt = Opt::parse();
 
-    let Some(first_script) = opt.script.first() else {
-        return Err(anyhow::anyhow!("No scripts specified (see --help)."));
-    };
-
-    let root = first_script.parent().unwrap_or_else(|| Path::new("."));
+    let root = Path::new(".");
     let provider = FileSystemSourceProvider::with_root(root.to_owned());
     let mut builder = ProgramBuilder::new(provider);
+
     for src in &opt.script {
         builder.add_script(&src.file_name().unwrap().to_string_lossy());
     }
+    for class in &opt.class {
+        builder.add_class(class);
+    }
+
     let parsed = builder.build().unwrap_or_else(|e| panic!("{}", e));
     let pcode = hir_to_pcode(&parsed, opt.swf_version);
     let output_path = opt
         .output
-        .unwrap_or_else(|| first_script.with_extension("swf"));
+        .or_else(|| opt.script.first().map(|s| s.with_extension("swf")))
+        .unwrap_or_else(|| PathBuf::from("output.swf"));
     let swf = pcode_to_swf(&pcode, opt.frame_rate)?;
     fs::write(&output_path, swf)?;
     Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,12 @@ struct Opt {
     #[arg(name = "FILE")]
     src: PathBuf,
 
+    /// Output file path. This will be overwritten if it already exists.
+    ///
+    /// If not specified, the input path (with ".swf" instead of ".as") will be used.
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
     /// SWF version to use.
     #[arg(short = 'v', long, default_value_t = 15)]
     swf_version: u8,
@@ -41,7 +47,8 @@ fn main() -> Result<()> {
             swf_version: opt.swf_version,
         }
     };
+    let output_path = opt.output.unwrap_or_else(|| opt.src.with_extension("swf"));
     let swf = pcode_to_swf(&pcode, opt.frame_rate)?;
-    fs::write(opt.src.with_extension("swf"), swf)?;
+    fs::write(&output_path, swf)?;
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,20 +2,23 @@ use anyhow::Result;
 use clap::Parser;
 use rascal_as2::program::{FileSystemSourceProvider, ProgramBuilder};
 use rascal_as2_codegen::hir_to_pcode;
-use rascal_as2_pcode::{CompiledProgram, PCode, pcode_to_swf};
+use rascal_as2_pcode::pcode_to_swf;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
 #[command(name = "rascal", version, author, about)]
 struct Opt {
-    /// Input source file to compile.
-    #[arg(name = "FILE")]
-    src: PathBuf,
+    /// A loose script (not class file) to add to the compiled program.
+    ///
+    /// Multiple scripts may be added to one program.
+    /// Scripts will be executed in order that they are added.
+    #[arg(name = "SCRIPT")]
+    script: Vec<PathBuf>,
 
     /// Output file path. This will be overwritten if it already exists.
     ///
-    /// If not specified, the input path (with ".swf" instead of ".as") will be used.
+    /// If not specified, the first script path (with ".swf" instead of ".as") will be used.
     #[arg(short, long)]
     output: Option<PathBuf>,
 
@@ -30,24 +33,22 @@ struct Opt {
 
 fn main() -> Result<()> {
     let opt = Opt::parse();
-    let filename = opt.src.to_string_lossy();
-    let pcode = if filename.ends_with(".as") {
-        let root = opt.src.parent().unwrap_or_else(|| Path::new("."));
-        let provider = FileSystemSourceProvider::with_root(root.to_owned());
-        let mut builder = ProgramBuilder::new(provider);
-        builder.add_script(&opt.src.file_name().unwrap().to_string_lossy());
-        let parsed = builder.build().unwrap_or_else(|e| panic!("{}", e));
-        hir_to_pcode(&parsed, opt.swf_version)
-    } else {
-        let src = fs::read_to_string(&opt.src)?;
-        let pcode = PCode::new(&filename, &src);
-        CompiledProgram {
-            initializer: Some(pcode.to_actions().unwrap_or_else(|e| panic!("{}", e))),
-            extra_modules: vec![],
-            swf_version: opt.swf_version,
-        }
+
+    let Some(first_script) = opt.script.first() else {
+        return Err(anyhow::anyhow!("No scripts specified (see --help)."));
     };
-    let output_path = opt.output.unwrap_or_else(|| opt.src.with_extension("swf"));
+
+    let root = first_script.parent().unwrap_or_else(|| Path::new("."));
+    let provider = FileSystemSourceProvider::with_root(root.to_owned());
+    let mut builder = ProgramBuilder::new(provider);
+    for src in &opt.script {
+        builder.add_script(&src.file_name().unwrap().to_string_lossy());
+    }
+    let parsed = builder.build().unwrap_or_else(|e| panic!("{}", e));
+    let pcode = hir_to_pcode(&parsed, opt.swf_version);
+    let output_path = opt
+        .output
+        .unwrap_or_else(|| first_script.with_extension("swf"));
     let swf = pcode_to_swf(&pcode, opt.frame_rate)?;
     fs::write(&output_path, swf)?;
     Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,7 +16,7 @@ struct Opt {
     ///
     /// It is valid to not specify any scripts - if so, the entry point of the program will be the first
     /// class (see `--class`) that contains a `static function main()` method.
-    #[arg(name = "SCRIPT")]
+    #[arg(name = "SCRIPT", help_heading = "Inputs")]
     script: Vec<PathBuf>,
 
     /// Output file path. This will be overwritten if it already exists.
@@ -24,7 +24,12 @@ struct Opt {
     /// If not specified:
     /// - If there are any scripts (see `SCRIPT`) specified, the first one will be used to determine the output path.
     /// - `output.swf` will be used if all else fails.
-    #[arg(short, long, verbatim_doc_comment)]
+    #[arg(
+        short,
+        long,
+        verbatim_doc_comment,
+        help_heading = "Generated SWF Options"
+    )]
     output: Option<PathBuf>,
 
     /// A name of a class to be added to the compiled program.
@@ -35,21 +40,26 @@ struct Opt {
     /// All classes will be loaded after any scripts (see `SCRIPT`).
     /// If no scripts are specified, one (and only one) class is expected to have an entry point in
     /// the form of a `static function main()` method.
-    #[arg(short, long)]
+    #[arg(short, long, help_heading = "Inputs")]
     class: Vec<String>,
 
     /// Adds a directory to be searched for classes.
     ///
     /// If no classpaths are specified, the current working directory will be used instead.
-    #[arg(long, long)]
+    #[arg(long, long, help_heading = "Inputs")]
     classpath: Vec<PathBuf>,
 
     /// SWF version to use.
-    #[arg(short = 'v', long, default_value_t = 15)]
+    #[arg(
+        short = 'v',
+        long,
+        default_value_t = 15,
+        help_heading = "Generated SWF Options"
+    )]
     swf_version: u8,
 
     /// Frame rate of the output SWF.
-    #[arg(long, default_value_t = 24.0)]
+    #[arg(long, default_value_t = 24.0, help_heading = "Generated SWF Options")]
     frame_rate: f32,
 }
 


### PR DESCRIPTION
```
Usage: rascal_cli [OPTIONS] [SCRIPT]...

Options:
  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

Inputs:
  -c, --class <CLASS>
          A name of a class to be added to the compiled program.

          This should be the canonical name of a class (e.g. `Foo` or `foo.bar.Baz`) which should be found in the current directory (e.g. at `Foo.as` or `foo/bar/Baz.as`).

          All classes will be loaded after any scripts (see `SCRIPT`). If no scripts are specified, one (and only one) class is expected to have an entry point in the form of a `static function main()` method.

      --classpath <CLASSPATH>
          Adds a directory to be searched for classes.

          If no classpaths are specified, the current working directory will be used instead.

  [SCRIPT]...
          A loose script (not class file) to add to the compiled program.

          Multiple scripts may be added to one program. Scripts will be executed in order that they are added, before any classes are loaded.

          It is valid to not specify any scripts - if so, the entry point of the program will be the first class (see `--class`) that contains a `static function main()` method.

Generated SWF Options:
  -o, --output <OUTPUT>
          Output file path. This will be overwritten if it already exists.

          If not specified:
          - If there are any scripts (see `SCRIPT`) specified, the first one will be used to determine the output path.
          - `output.swf` will be used if all else fails.

  -v, --swf-version <SWF_VERSION>
          SWF version to use

          [default: 15]

      --frame-rate <FRAME_RATE>
          Frame rate of the output SWF

          [default: 24]
```