### PR TITLE
feat(codegen): Fold constants to ints with int() special function

### DIFF
--- a/crates/rascal/src/internal/as2/hir/constant_folder.rs
+++ b/crates/rascal/src/internal/as2/hir/constant_folder.rs
@@ -28,6 +28,13 @@ impl MutVisitor for ConstantFolder {
                     self.anything_changed = true;
                 }
             }
+            ExprKind::CastToInteger(value) => {
+                if let ExprKind::Constant(value) = &value.value
+                    && let Some(value) = as_int(value, i32::MIN) {
+                        expr.value = ExprKind::Constant(ConstantKind::Integer(value));
+                        self.anything_changed = true;
+                    }
+            }
             _ => {}
         }
     }
@@ -68,11 +75,11 @@ fn as_float(value: &'_ ConstantKind) -> Option<f64> {
     }
 }
 
-fn as_int(value: &'_ ConstantKind) -> Option<i32> {
+fn as_int(value: &'_ ConstantKind, nan: i32) -> Option<i32> {
     match value {
         ConstantKind::String(_) => {
             let value = as_float(value).unwrap_or_default();
-            Some(if value.is_nan() { 0 } else { value as i32 })
+            Some(if value.is_nan() { nan } else { value as i32 })
         }
         ConstantKind::Boolean(true) => Some(1),
         ConstantKind::Boolean(false) => Some(0),
@@ -155,7 +162,7 @@ fn evaluate_unary_operator(op: UnaryOperator, value: &ConstantKind) -> Option<Co
             }
         }
         UnaryOperator::BitNot => {
-            if let Some(value) = as_int(value) {
+            if let Some(value) = as_int(value, 0) {
                 ConstantKind::Integer(!value)
             } else {
                 return None;

--- a/crates/rascal/src/internal/as2/lexer/snapshots/rascal__internal__as2__lexer__tests__all_samples@constant_folding.as.snap
+++ b/crates/rascal/src/internal/as2/lexer/snapshots/rascal__internal__as2__lexer__tests__all_samples@constant_folding.as.snap
@@ -3350,3 +3350,840 @@ input_file: samples/as2/constant_folding.as
     start: 1694
     end: 1695
   raw: "\n"
+- kind: Newline
+  span:
+    start: 1695
+    end: 1696
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1720
+    end: 1725
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1725
+    end: 1726
+  raw: (
+- kind: Identifier
+  span:
+    start: 1726
+    end: 1729
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1729
+    end: 1730
+  raw: (
+- kind: Identifier
+  span:
+    start: 1730
+    end: 1734
+  raw: "true"
+- kind: CloseParen
+  span:
+    start: 1734
+    end: 1735
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1735
+    end: 1736
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1736
+    end: 1737
+  raw: ;
+- kind: Newline
+  span:
+    start: 1737
+    end: 1738
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1738
+    end: 1743
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1743
+    end: 1744
+  raw: (
+- kind: Identifier
+  span:
+    start: 1744
+    end: 1747
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1747
+    end: 1748
+  raw: (
+- kind: Identifier
+  span:
+    start: 1748
+    end: 1753
+  raw: "false"
+- kind: CloseParen
+  span:
+    start: 1753
+    end: 1754
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1754
+    end: 1755
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1755
+    end: 1756
+  raw: ;
+- kind: Newline
+  span:
+    start: 1756
+    end: 1757
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1765
+    end: 1770
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1770
+    end: 1771
+  raw: (
+- kind: Identifier
+  span:
+    start: 1771
+    end: 1774
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1774
+    end: 1775
+  raw: (
+- kind: Integer
+  span:
+    start: 1775
+    end: 1776
+  raw: "0"
+- kind: CloseParen
+  span:
+    start: 1776
+    end: 1777
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1777
+    end: 1778
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1778
+    end: 1779
+  raw: ;
+- kind: Newline
+  span:
+    start: 1779
+    end: 1780
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1780
+    end: 1785
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1785
+    end: 1786
+  raw: (
+- kind: Identifier
+  span:
+    start: 1786
+    end: 1789
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1789
+    end: 1790
+  raw: (
+- kind: Integer
+  span:
+    start: 1790
+    end: 1791
+  raw: "1"
+- kind: CloseParen
+  span:
+    start: 1791
+    end: 1792
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1792
+    end: 1793
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1793
+    end: 1794
+  raw: ;
+- kind: Newline
+  span:
+    start: 1794
+    end: 1795
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1795
+    end: 1800
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1800
+    end: 1801
+  raw: (
+- kind: Identifier
+  span:
+    start: 1801
+    end: 1804
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1804
+    end: 1805
+  raw: (
+- kind: OpenParen
+  span:
+    start: 1805
+    end: 1806
+  raw: (
+- kind:
+    Operator: Sub
+  span:
+    start: 1806
+    end: 1807
+  raw: "-"
+- kind: Integer
+  span:
+    start: 1807
+    end: 1808
+  raw: "1"
+- kind: CloseParen
+  span:
+    start: 1808
+    end: 1809
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1809
+    end: 1810
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1810
+    end: 1811
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1811
+    end: 1812
+  raw: ;
+- kind: Newline
+  span:
+    start: 1812
+    end: 1813
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1813
+    end: 1818
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1818
+    end: 1819
+  raw: (
+- kind: Identifier
+  span:
+    start: 1819
+    end: 1822
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1822
+    end: 1823
+  raw: (
+- kind: Integer
+  span:
+    start: 1823
+    end: 1824
+  raw: "5"
+- kind: CloseParen
+  span:
+    start: 1824
+    end: 1825
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1825
+    end: 1826
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1826
+    end: 1827
+  raw: ;
+- kind: Newline
+  span:
+    start: 1827
+    end: 1828
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1838
+    end: 1843
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1843
+    end: 1844
+  raw: (
+- kind: Identifier
+  span:
+    start: 1844
+    end: 1847
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1847
+    end: 1848
+  raw: (
+- kind: Float
+  span:
+    start: 1848
+    end: 1851
+  raw: "0.0"
+- kind: CloseParen
+  span:
+    start: 1851
+    end: 1852
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1852
+    end: 1853
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1853
+    end: 1854
+  raw: ;
+- kind: Newline
+  span:
+    start: 1854
+    end: 1855
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1855
+    end: 1860
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1860
+    end: 1861
+  raw: (
+- kind: Identifier
+  span:
+    start: 1861
+    end: 1864
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1864
+    end: 1865
+  raw: (
+- kind: Float
+  span:
+    start: 1865
+    end: 1868
+  raw: "0.1"
+- kind: CloseParen
+  span:
+    start: 1868
+    end: 1869
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1869
+    end: 1870
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1870
+    end: 1871
+  raw: ;
+- kind: Newline
+  span:
+    start: 1871
+    end: 1872
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1872
+    end: 1877
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1877
+    end: 1878
+  raw: (
+- kind: Identifier
+  span:
+    start: 1878
+    end: 1881
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1881
+    end: 1882
+  raw: (
+- kind: Float
+  span:
+    start: 1882
+    end: 1885
+  raw: "5.2"
+- kind: CloseParen
+  span:
+    start: 1885
+    end: 1886
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1886
+    end: 1887
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1887
+    end: 1888
+  raw: ;
+- kind: Newline
+  span:
+    start: 1888
+    end: 1889
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1900
+    end: 1905
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1905
+    end: 1906
+  raw: (
+- kind: Identifier
+  span:
+    start: 1906
+    end: 1909
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1909
+    end: 1910
+  raw: (
+- kind:
+    String: Double
+  span:
+    start: 1910
+    end: 1915
+  raw: "123"
+- kind: CloseParen
+  span:
+    start: 1915
+    end: 1916
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1916
+    end: 1917
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1917
+    end: 1918
+  raw: ;
+- kind: Newline
+  span:
+    start: 1918
+    end: 1919
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1919
+    end: 1924
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1924
+    end: 1925
+  raw: (
+- kind: Identifier
+  span:
+    start: 1925
+    end: 1928
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1928
+    end: 1929
+  raw: (
+- kind:
+    String: Double
+  span:
+    start: 1929
+    end: 1934
+  raw: "2.5"
+- kind: CloseParen
+  span:
+    start: 1934
+    end: 1935
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1935
+    end: 1936
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1936
+    end: 1937
+  raw: ;
+- kind: Newline
+  span:
+    start: 1937
+    end: 1938
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1938
+    end: 1943
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1943
+    end: 1944
+  raw: (
+- kind: Identifier
+  span:
+    start: 1944
+    end: 1947
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1947
+    end: 1948
+  raw: (
+- kind:
+    String: Double
+  span:
+    start: 1948
+    end: 1951
+  raw: "0"
+- kind: CloseParen
+  span:
+    start: 1951
+    end: 1952
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1952
+    end: 1953
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1953
+    end: 1954
+  raw: ;
+- kind: Newline
+  span:
+    start: 1954
+    end: 1955
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1955
+    end: 1960
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1960
+    end: 1961
+  raw: (
+- kind: Identifier
+  span:
+    start: 1961
+    end: 1964
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1964
+    end: 1965
+  raw: (
+- kind:
+    String: Double
+  span:
+    start: 1965
+    end: 1967
+  raw: ""
+- kind: CloseParen
+  span:
+    start: 1967
+    end: 1968
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1968
+    end: 1969
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1969
+    end: 1970
+  raw: ;
+- kind: Newline
+  span:
+    start: 1970
+    end: 1971
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1971
+    end: 1976
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1976
+    end: 1977
+  raw: (
+- kind: Identifier
+  span:
+    start: 1977
+    end: 1980
+  raw: int
+- kind: OpenParen
+  span:
+    start: 1980
+    end: 1981
+  raw: (
+- kind:
+    String: Double
+  span:
+    start: 1981
+    end: 1987
+  raw: "true"
+- kind: CloseParen
+  span:
+    start: 1987
+    end: 1988
+  raw: )
+- kind: CloseParen
+  span:
+    start: 1988
+    end: 1989
+  raw: )
+- kind: Semicolon
+  span:
+    start: 1989
+    end: 1990
+  raw: ;
+- kind: Newline
+  span:
+    start: 1990
+    end: 1991
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 1991
+    end: 1996
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 1996
+    end: 1997
+  raw: (
+- kind: Identifier
+  span:
+    start: 1997
+    end: 2000
+  raw: int
+- kind: OpenParen
+  span:
+    start: 2000
+    end: 2001
+  raw: (
+- kind:
+    String: Double
+  span:
+    start: 2001
+    end: 2008
+  raw: "false"
+- kind: CloseParen
+  span:
+    start: 2008
+    end: 2009
+  raw: )
+- kind: CloseParen
+  span:
+    start: 2009
+    end: 2010
+  raw: )
+- kind: Semicolon
+  span:
+    start: 2010
+    end: 2011
+  raw: ;
+- kind: Newline
+  span:
+    start: 2011
+    end: 2012
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 2051
+    end: 2056
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 2056
+    end: 2057
+  raw: (
+- kind: Identifier
+  span:
+    start: 2057
+    end: 2060
+  raw: int
+- kind: OpenParen
+  span:
+    start: 2060
+    end: 2061
+  raw: (
+- kind: Identifier
+  span:
+    start: 2061
+    end: 2065
+  raw: "null"
+- kind: CloseParen
+  span:
+    start: 2065
+    end: 2066
+  raw: )
+- kind: CloseParen
+  span:
+    start: 2066
+    end: 2067
+  raw: )
+- kind: Semicolon
+  span:
+    start: 2067
+    end: 2068
+  raw: ;
+- kind: Newline
+  span:
+    start: 2068
+    end: 2069
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 2069
+    end: 2074
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 2074
+    end: 2075
+  raw: (
+- kind: Identifier
+  span:
+    start: 2075
+    end: 2078
+  raw: int
+- kind: OpenParen
+  span:
+    start: 2078
+    end: 2079
+  raw: (
+- kind: Identifier
+  span:
+    start: 2079
+    end: 2088
+  raw: undefined
+- kind: CloseParen
+  span:
+    start: 2088
+    end: 2089
+  raw: )
+- kind: CloseParen
+  span:
+    start: 2089
+    end: 2090
+  raw: )
+- kind: Semicolon
+  span:
+    start: 2090
+    end: 2091
+  raw: ;
+- kind: Newline
+  span:
+    start: 2091
+    end: 2092
+  raw: "\n"
+- kind: Identifier
+  span:
+    start: 2092
+    end: 2097
+  raw: trace
+- kind: OpenParen
+  span:
+    start: 2097
+    end: 2098
+  raw: (
+- kind: Identifier
+  span:
+    start: 2098
+    end: 2101
+  raw: int
+- kind: OpenParen
+  span:
+    start: 2101
+    end: 2102
+  raw: (
+- kind: Identifier
+  span:
+    start: 2102
+    end: 2105
+  raw: foo
+- kind: CloseParen
+  span:
+    start: 2105
+    end: 2106
+  raw: )
+- kind: CloseParen
+  span:
+    start: 2106
+    end: 2107
+  raw: )
+- kind: Semicolon
+  span:
+    start: 2107
+    end: 2108
+  raw: ;
+- kind: Newline
+  span:
+    start: 2108
+    end: 2109
+  raw: "\n"

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@constant_folding.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@constant_folding.as.snap
@@ -1115,6 +1115,237 @@ Ok:
             value:
               Constant:
                 Float: NaN
+    - Expr:
+        span:
+          start: 1720
+          end: 1736
+        value:
+          Trace:
+            span:
+              start: 1726
+              end: 1735
+            value:
+              Constant:
+                Integer: 1
+    - Expr:
+        span:
+          start: 1738
+          end: 1755
+        value:
+          Trace:
+            span:
+              start: 1744
+              end: 1754
+            value:
+              Constant:
+                Integer: 0
+    - Expr:
+        span:
+          start: 1765
+          end: 1778
+        value:
+          Trace:
+            span:
+              start: 1771
+              end: 1777
+            value:
+              Constant:
+                Integer: 0
+    - Expr:
+        span:
+          start: 1780
+          end: 1793
+        value:
+          Trace:
+            span:
+              start: 1786
+              end: 1792
+            value:
+              Constant:
+                Integer: 1
+    - Expr:
+        span:
+          start: 1795
+          end: 1811
+        value:
+          Trace:
+            span:
+              start: 1801
+              end: 1810
+            value:
+              Constant:
+                Integer: -1
+    - Expr:
+        span:
+          start: 1813
+          end: 1826
+        value:
+          Trace:
+            span:
+              start: 1819
+              end: 1825
+            value:
+              Constant:
+                Integer: 5
+    - Expr:
+        span:
+          start: 1838
+          end: 1853
+        value:
+          Trace:
+            span:
+              start: 1844
+              end: 1852
+            value:
+              Constant:
+                Integer: 0
+    - Expr:
+        span:
+          start: 1855
+          end: 1870
+        value:
+          Trace:
+            span:
+              start: 1861
+              end: 1869
+            value:
+              Constant:
+                Integer: 0
+    - Expr:
+        span:
+          start: 1872
+          end: 1887
+        value:
+          Trace:
+            span:
+              start: 1878
+              end: 1886
+            value:
+              Constant:
+                Integer: 5
+    - Expr:
+        span:
+          start: 1900
+          end: 1917
+        value:
+          Trace:
+            span:
+              start: 1906
+              end: 1916
+            value:
+              Constant:
+                Integer: 123
+    - Expr:
+        span:
+          start: 1919
+          end: 1936
+        value:
+          Trace:
+            span:
+              start: 1925
+              end: 1935
+            value:
+              Constant:
+                Integer: 2
+    - Expr:
+        span:
+          start: 1938
+          end: 1953
+        value:
+          Trace:
+            span:
+              start: 1944
+              end: 1952
+            value:
+              Constant:
+                Integer: 0
+    - Expr:
+        span:
+          start: 1955
+          end: 1969
+        value:
+          Trace:
+            span:
+              start: 1961
+              end: 1968
+            value:
+              Constant:
+                Integer: -2147483648
+    - Expr:
+        span:
+          start: 1971
+          end: 1989
+        value:
+          Trace:
+            span:
+              start: 1977
+              end: 1988
+            value:
+              Constant:
+                Integer: -2147483648
+    - Expr:
+        span:
+          start: 1991
+          end: 2010
+        value:
+          Trace:
+            span:
+              start: 1997
+              end: 2009
+            value:
+              Constant:
+                Integer: -2147483648
+    - Expr:
+        span:
+          start: 2051
+          end: 2067
+        value:
+          Trace:
+            span:
+              start: 2057
+              end: 2066
+            value:
+              CastToInteger:
+                span:
+                  start: 2061
+                  end: 2065
+                value:
+                  Constant:
+                    Identifier: "null"
+    - Expr:
+        span:
+          start: 2069
+          end: 2090
+        value:
+          Trace:
+            span:
+              start: 2075
+              end: 2089
+            value:
+              CastToInteger:
+                span:
+                  start: 2079
+                  end: 2088
+                value:
+                  Constant:
+                    Identifier: undefined
+    - Expr:
+        span:
+          start: 2092
+          end: 2107
+        value:
+          Trace:
+            span:
+              start: 2098
+              end: 2106
+            value:
+              CastToInteger:
+                span:
+                  start: 2102
+                  end: 2105
+                value:
+                  Constant:
+                    Identifier: foo
   interfaces: []
   classes: []
   custom_pcodes: []

--- a/crates/rascal/src/snapshots/rascal__tests__all_samples@constant_folding.as.snap
+++ b/crates/rascal/src/snapshots/rascal__tests__all_samples@constant_folding.as.snap
@@ -288,6 +288,64 @@ initializer:
     - Push:
         - Float: NaN
     - Trace
+    - Push:
+        - Integer: 1
+    - Trace
+    - Push:
+        - Integer: 0
+    - Trace
+    - Push:
+        - Integer: 0
+    - Trace
+    - Push:
+        - Integer: 1
+    - Trace
+    - Push:
+        - Integer: -1
+    - Trace
+    - Push:
+        - Integer: 5
+    - Trace
+    - Push:
+        - Integer: 0
+    - Trace
+    - Push:
+        - Integer: 0
+    - Trace
+    - Push:
+        - Integer: 5
+    - Trace
+    - Push:
+        - Integer: 123
+    - Trace
+    - Push:
+        - Integer: 2
+    - Trace
+    - Push:
+        - Integer: 0
+    - Trace
+    - Push:
+        - Integer: -2147483648
+    - Trace
+    - Push:
+        - Integer: -2147483648
+    - Trace
+    - Push:
+        - Integer: -2147483648
+    - Trace
+    - Push:
+        - "Null"
+    - ToInteger
+    - Trace
+    - Push:
+        - Undefined
+    - ToInteger
+    - Trace
+    - Push:
+        - Constant: 0
+    - GetVariable
+    - ToInteger
+    - Trace
   label_positions: {}
 extra_modules: []
 compile_options:

--- a/samples/as2/constant_folding.as
+++ b/samples/as2/constant_folding.as
@@ -114,3 +114,28 @@ trace(1 - 2.0)
 trace(1.0 - 2);
 trace(true - false);
 trace(true - "false");
+
+// -- Int cast
+// Bools
+trace(int(true));
+trace(int(false));
+// Ints
+trace(int(0));
+trace(int(1));
+trace(int((-1)));
+trace(int(5));
+// Floats
+trace(int(0.0));
+trace(int(0.1));
+trace(int(5.2));
+// Strings
+trace(int("123"));
+trace(int("2.5"));
+trace(int("0"));
+trace(int(""));
+trace(int("true"));
+trace(int("false"));
+// Confirm anything else isn't touched
+trace(int(null));
+trace(int(undefined));
+trace(int(foo));


### PR DESCRIPTION
It looks like this is the only cast that seems to be folded; `number("1")` and `string(1)` always generate opcodes.