### PR TITLE
Fix some class issues

### DIFF
--- a/crates/rascal/src/internal.rs
+++ b/crates/rascal/src/internal.rs
@@ -1,4 +1,5 @@
 pub(crate) mod as2;
 pub(crate) mod as2_codegen;
 pub(crate) mod as2_pcode;
+pub(crate) mod definitions;
 pub(crate) mod span;

--- a/crates/rascal/src/internal/as2/hir.rs
+++ b/crates/rascal/src/internal/as2/hir.rs
@@ -1,4 +1,5 @@
 pub(crate) mod constant_folder;
+pub mod optimize_virtual_properties;
 pub(crate) mod register_promoter;
 pub(crate) mod scope;
 pub(crate) mod visitor;

--- a/crates/rascal/src/internal/as2/hir/optimize_virtual_properties.rs
+++ b/crates/rascal/src/internal/as2/hir/optimize_virtual_properties.rs
@@ -1,0 +1,130 @@
+use crate::internal::as2::hir::scope::Scope;
+use crate::internal::as2::hir::visitor::{MutVisitor, walk_expr, walk_program, walk_statement};
+use crate::internal::as2::hir::{BinaryOperator, ConstantKind, Expr, ExprKind, Function};
+use crate::internal::as2::resolver::identifiers_to_path;
+use crate::internal::definitions::{FieldDefinition, ProgramDefinition};
+
+struct VirtualPropertyOptimizer {
+    definition: ProgramDefinition,
+    scope: Scope,
+}
+
+struct FieldInfo<'a> {
+    owner: &'a Expr,
+    definition: &'a FieldDefinition,
+}
+
+impl VirtualPropertyOptimizer {
+    pub fn get_field<'a>(&'a self, expr: &'a ExprKind) -> Option<FieldInfo<'a>> {
+        let mut path = identifiers_to_path(expr).ok()?;
+        if path.len() < 2 {
+            return None;
+        }
+        let first = path.remove(0);
+        let last = path.pop()?;
+        let mut type_name = if let Some(first_variable) = self.scope.defined_variables.get(first)
+            && let Some(type_name) = &first_variable.type_name
+        {
+            &type_name.value
+        } else {
+            return None;
+        };
+
+        path.reverse(); // turn [foo, bar, baz] into [baz, bar, foo] for easy iteration
+        while let Some(segment) = path.pop() {
+            if let Some(type_definition) = self.definition.get_field(type_name, segment) {
+                if let Some(next_name) = &type_definition.type_name {
+                    type_name = next_name;
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        }
+
+        let ExprKind::Field(owner, _) = expr else {
+            unreachable!()
+        };
+
+        Some(FieldInfo {
+            owner,
+            definition: self.definition.get_field(type_name, last)?,
+        })
+    }
+}
+
+impl MutVisitor for VirtualPropertyOptimizer {
+    fn visit_expr(&mut self, expr: &mut Expr) {
+        if let ExprKind::BinaryOperator(
+            BinaryOperator::Assign | BinaryOperator::AddAssign,
+            path,
+            value,
+        ) = &mut expr.value
+        {
+            if let Some(field) = self.get_field(&path.value)
+                && field.definition.is_virtual
+            {
+                expr.value = ExprKind::Call {
+                    name: Box::new(Expr::new(
+                        expr.span,
+                        ExprKind::Field(
+                            Box::new(field.owner.clone()),
+                            Box::new(Expr::new(
+                                expr.span,
+                                ExprKind::Constant(ConstantKind::String(format!(
+                                    "__set__{}",
+                                    field.definition.name.clone()
+                                ))),
+                            )),
+                        ),
+                    )),
+                    args: vec![*value.clone()],
+                };
+            };
+            return;
+        }
+
+        walk_expr(self, expr);
+
+        if let Some(field) = self.get_field(&expr.value)
+            && field.definition.is_virtual
+        {
+            expr.value = ExprKind::Call {
+                name: Box::new(Expr::new(
+                    expr.span,
+                    ExprKind::Field(
+                        Box::new(field.owner.clone()),
+                        Box::new(Expr::new(
+                            expr.span,
+                            ExprKind::Constant(ConstantKind::String(format!(
+                                "__get__{}",
+                                field.definition.name.clone()
+                            ))),
+                        )),
+                    ),
+                )),
+                args: vec![],
+            };
+        };
+    }
+
+    fn visit_function(&mut self, function: &mut Function) {
+        let old_scope = std::mem::replace(&mut self.scope, function.scope.clone());
+
+        for statement in &mut function.body {
+            walk_statement(self, statement);
+        }
+
+        self.scope = old_scope;
+    }
+}
+
+pub fn optimize_virtual_properties(program: &mut crate::Program) {
+    let definition = ProgramDefinition::from(&*program);
+    let mut promoter = VirtualPropertyOptimizer {
+        definition,
+        scope: Scope::default(),
+    };
+    walk_program(&mut promoter, program);
+}

--- a/crates/rascal/src/internal/as2/hir/register_promoter.rs
+++ b/crates/rascal/src/internal/as2/hir/register_promoter.rs
@@ -1,7 +1,8 @@
+use crate::Program;
 use crate::internal::as2::ast::BinaryOperator;
-use crate::internal::as2::hir::visitor::{MutVisitor, walk_document, walk_expr, walk_statement};
+use crate::internal::as2::hir::visitor::{MutVisitor, walk_expr, walk_program, walk_statement};
 use crate::internal::as2::hir::{
-    ConstantKind, Document, EnumeratorTarget, Expr, ExprKind, ForCondition, Function, StatementKind,
+    ConstantKind, EnumeratorTarget, Expr, ExprKind, ForCondition, Function, StatementKind,
 };
 use crate::internal::span::Span;
 use indexmap::IndexMap;
@@ -113,8 +114,8 @@ impl MutVisitor for RegisterPromoter {
     }
 }
 
-pub fn promote_variables_to_registers(document: &mut Document) {
+pub fn promote_variables_to_registers(program: &mut Program) {
     let mut promoter = RegisterPromoter::default();
 
-    walk_document(&mut promoter, document);
+    walk_program(&mut promoter, program);
 }

--- a/crates/rascal/src/internal/as2/hir/scope.rs
+++ b/crates/rascal/src/internal/as2/hir/scope.rs
@@ -3,6 +3,7 @@ use crate::internal::as2::hir::{
     ConstantKind, Declaration, EnumeratorTarget, Expr, ExprKind, ForCondition, Function,
     FunctionArgument, StatementKind,
 };
+use crate::internal::span::Spanned;
 use indexmap::{IndexMap, IndexSet};
 use serde::Serialize;
 
@@ -10,6 +11,7 @@ use serde::Serialize;
 pub struct Variable {
     pub used: bool,
     pub used_in_inner_scope: bool,
+    pub type_name: Option<Spanned<String>>,
 }
 #[derive(Debug, Clone, Serialize, PartialEq, Default)]
 pub struct Scope {
@@ -19,18 +21,31 @@ pub struct Scope {
 }
 
 impl Scope {
-    pub fn for_function(args: &Vec<FunctionArgument>, body: &mut Vec<StatementKind>) -> Self {
+    pub fn for_function(
+        args: &Vec<FunctionArgument>,
+        body: &mut Vec<StatementKind>,
+        this_type: Option<Spanned<String>>,
+        super_type: Option<Spanned<String>>,
+    ) -> Self {
         let mut scope = Scope::default();
         // These must be defined before any arguments, in this order: this arguments super _root _parent _global
-        scope
-            .defined_variables
-            .insert("this".to_string(), Variable::default());
+        scope.defined_variables.insert(
+            "this".to_string(),
+            Variable {
+                type_name: this_type,
+                ..Default::default()
+            },
+        );
         scope
             .defined_variables
             .insert("arguments".to_string(), Variable::default());
-        scope
-            .defined_variables
-            .insert("super".to_string(), Variable::default());
+        scope.defined_variables.insert(
+            "super".to_string(),
+            Variable {
+                type_name: super_type,
+                ..Default::default()
+            },
+        );
         scope
             .defined_variables
             .insert("_root".to_string(), Variable::default());
@@ -73,11 +88,12 @@ impl VariableFinder {
         }
     }
 
-    fn declare_new_variable(&mut self, name: String) {
+    fn declare_new_variable(&mut self, name: String, type_name: Option<Spanned<String>>) {
         self.0.defined_variables.insert(
             name,
             Variable {
                 used: true,
+                type_name,
                 ..Default::default()
             },
         );
@@ -107,7 +123,10 @@ impl MutVisitor for VariableFinder {
     }
 
     fn visit_declaration(&mut self, declaration: &mut Declaration) {
-        self.declare_new_variable(declaration.name.value.clone());
+        self.declare_new_variable(
+            declaration.name.value.clone(),
+            declaration.type_name.clone(),
+        );
         if let Some(value) = &mut declaration.value {
             self.visit_expr(value);
         }
@@ -127,7 +146,7 @@ impl MutVisitor for VariableFinder {
                 ..
             } => {
                 if *declare {
-                    self.declare_new_variable(name.clone());
+                    self.declare_new_variable(name.clone(), None);
                 } else {
                     self.mark_variable_used(name, false);
                 }

--- a/crates/rascal/src/internal/as2/hir/visitor.rs
+++ b/crates/rascal/src/internal/as2/hir/visitor.rs
@@ -1,3 +1,4 @@
+use crate::Program;
 use crate::internal::as2::hir::{
     Declaration, Document, Expr, ExprKind, ForCondition, Function, StatementKind, SwitchElement,
 };
@@ -276,5 +277,17 @@ pub fn walk_document<V: MutVisitor + ?Sized>(visitor: &mut V, document: &mut Doc
             visitor.visit_function(&mut class.constructor);
         }
         Document::Invalid => {}
+    }
+}
+
+pub fn walk_program<V: MutVisitor + ?Sized>(visitor: &mut V, program: &mut Program) {
+    for class in &mut program.classes {
+        for method in class.functions.values_mut() {
+            visitor.visit_function(&mut method.function);
+        }
+        visitor.visit_function(&mut class.constructor);
+    }
+    for statement in &mut program.initial_script {
+        visitor.visit_statement(statement);
     }
 }

--- a/crates/rascal/src/internal/as2/resolver.rs
+++ b/crates/rascal/src/internal/as2/resolver.rs
@@ -153,7 +153,7 @@ impl<'a> ModuleContext<'a> {
 
     fn add_dependency_by_path(&mut self, expr: &hir::Expr, required: bool) -> bool {
         if let Ok(path) = identifiers_to_path(expr) {
-            self.add_dependency(expr.span, &path, required)
+            self.add_dependency(expr.span, &path.join("."), required)
         } else {
             false
         }
@@ -165,7 +165,7 @@ impl<'a> ModuleContext<'a> {
 }
 
 /// Turns `foo.bar.baz` (Field{parent=Field{parent=foo, child={bar}}, child=baz}) into `"foo.bar.baz"`
-fn identifiers_to_path(mut expr: &hir::ExprKind) -> Result<String, ()> {
+pub fn identifiers_to_path(mut expr: &hir::ExprKind) -> Result<Vec<&str>, ()> {
     let mut path = vec![];
 
     loop {
@@ -189,7 +189,7 @@ fn identifiers_to_path(mut expr: &hir::ExprKind) -> Result<String, ()> {
     }
 
     path.reverse();
-    Ok(path.join("."))
+    Ok(path)
 }
 
 pub fn resolve_hir<P: SourceProvider>(

--- a/crates/rascal/src/internal/as2/resolver.rs
+++ b/crates/rascal/src/internal/as2/resolver.rs
@@ -21,7 +21,8 @@ struct ModuleContext<'a> {
     provider: &'a dyn SourceProvider,
     known_script_paths: &'a IndexSet<String>,
     is_script: bool,
-    class_name: String,
+    class_name: Option<Spanned<String>>,
+    super_name: Option<Spanned<String>>,
     class_members: HashMap<String, bool>,
 }
 
@@ -29,7 +30,7 @@ impl<'a> ModuleContext<'a> {
     fn new(
         provider: &'a dyn SourceProvider,
         is_script: bool,
-        class_name: String,
+        class_name: Option<Spanned<String>>,
         known_script_paths: &'a IndexSet<String>,
     ) -> Self {
         Self {
@@ -39,9 +40,14 @@ impl<'a> ModuleContext<'a> {
             provider,
             is_script,
             class_name,
+            super_name: None,
             class_members: HashMap::new(),
             known_script_paths,
         }
+    }
+
+    fn set_super_name(&mut self, name: Option<Spanned<String>>) {
+        self.super_name = name;
     }
 
     fn import(&mut self, span: Span, path: Vec<String>, name: String) {
@@ -59,11 +65,15 @@ impl<'a> ModuleContext<'a> {
     }
 
     fn expand_identifier(&self, name: String, span: Span) -> Option<hir::Expr> {
-        if let Some(is_static) = self.class_members.get(&name) {
+        if let Some(is_static) = self.class_members.get(&name)
+            && let Some(class_name) = &self.class_name
+        {
             let parent = if *is_static {
                 Box::new(hir::Expr::new(
                     span,
-                    hir::ExprKind::Constant(hir::ConstantKind::Identifier(self.class_name.clone())),
+                    hir::ExprKind::Constant(hir::ConstantKind::Identifier(
+                        class_name.value.clone(),
+                    )),
                 ))
             } else {
                 Box::new(hir::Expr::new(
@@ -192,7 +202,11 @@ pub fn resolve_hir<P: SourceProvider>(
     let mut context = ModuleContext::new(
         provider,
         is_script,
-        expected_name.to_owned(),
+        if expected_name.is_empty() {
+            None
+        } else {
+            Some(Spanned::new(Span::default(), expected_name.to_owned()))
+        },
         known_script_paths,
     );
     let document = if is_script {
@@ -235,6 +249,7 @@ fn resolve_class_or_interface(
                 extends,
                 body,
             } => {
+                context.set_super_name(extends.clone());
                 if name.value == expected_name {
                     if result.is_some() {
                         context.error(
@@ -261,6 +276,7 @@ fn resolve_class_or_interface(
                 implements,
                 members,
             } => {
+                context.set_super_name(extends.clone());
                 if name.value == expected_name {
                     if result.is_some() {
                         context.error(
@@ -943,7 +959,12 @@ fn resolve_function(
             register: None,
         })
         .collect();
-    let scope = Scope::for_function(&args, &mut body);
+    let scope = Scope::for_function(
+        &args,
+        &mut body,
+        context.class_name.clone(),
+        context.super_name.clone(),
+    );
     hir::Function {
         signature: hir::FunctionSignature {
             name: input

--- a/crates/rascal/src/internal/as2_codegen.rs
+++ b/crates/rascal/src/internal/as2_codegen.rs
@@ -1,3 +1,4 @@
+use crate::CompileOptions;
 use crate::internal::as2::hir::{Class, Interface, StatementKind};
 use crate::internal::as2_codegen::builder::CodeBuilder;
 use crate::internal::as2_codegen::context::ScriptContext;
@@ -38,9 +39,9 @@ pub fn interface_to_actions(interface: &Interface) -> Actions {
 
                     // If we extend something, set that association too
                     if let Some(extends) = &interface.extends {
-                        get_type_path(builder, extends, true);
+                        get_type_path(builder, extends, true, true);
                         builder.push(1);
-                        get_type_path(builder, &interface.name, true);
+                        get_type_path(builder, &interface.name, true, true);
                         builder.action_with_stack_delta(Action::ImplementsOp, -3);
                     }
                 }
@@ -84,7 +85,7 @@ fn create_if_not_exists<F>(
     builder.action(Action::Pop);
 }
 
-pub fn class_to_actions(class: &Class) -> Actions {
+pub fn class_to_actions(compile_options: &CompileOptions, class: &Class) -> Actions {
     generate_actions(|context, builder| {
         let segments: Vec<&str> = class.name.split(".").collect();
         for i in 1..=segments.len() {
@@ -100,29 +101,44 @@ pub fn class_to_actions(class: &Class) -> Actions {
                     builder.action(Action::StoreRegister(1));
                     builder.action(Action::SetMember);
 
-                    // If we extend something, set that association too
-                    // TODO: This doesn't handle paths yet ("foo.bar.Baz")
-                    if let Some(extends) = &class.extends {
-                        get_type_path(builder, &class.name, false);
-                        get_type_path(builder, extends, false);
-                        builder.action(Action::Extends);
+                    let needs_prototype_setup = if let Some(extends) = &class.extends {
+                        // If we extend something, set that association too
+                        if compile_options.swf_version >= 7 {
+                            // Extends opcode was added in SWF 7
+                            get_type_path(builder, &class.name, false, true);
+                            get_type_path(builder, extends, false, true);
+                            builder.action(Action::Extends);
+                            true
+                        } else {
+                            // ThisClass.prototype = new SuperClass();
+                            get_type_path(builder, &class.name, true, true);
+                            builder.push("prototype");
+                            builder.push(0);
+                            get_type_path(builder, extends, false, false);
+                            builder.action(Action::NewObject);
+                            builder.action(Action::StoreRegister(2));
+                            builder.action(Action::SetMember);
+                            false
+                        }
+                    } else {
+                        true
+                    };
+
+                    if needs_prototype_setup {
+                        builder.push(PushValue::Register(1));
+                        builder.push("prototype");
+                        builder.action(Action::GetMember);
+                        builder.action(Action::StoreRegister(2));
+                        builder.action(Action::Pop);
                     }
 
-                    // Set up the prototype
-                    builder.push(PushValue::Register(1));
-                    builder.push("prototype");
-                    builder.action(Action::GetMember);
-                    builder.action(Action::StoreRegister(2));
-                    builder.action(Action::Pop);
-
                     // If we implement some interfaces, set those associations too
-                    // TODO: This doesn't handle paths yet ("foo.bar.Baz")
                     if !class.implements.is_empty() {
                         for name in &class.implements {
-                            get_type_path(builder, name, true);
+                            get_type_path(builder, name, true, true);
                         }
                         builder.push(class.implements.len() as i32);
-                        get_type_path(builder, &class.name, true);
+                        get_type_path(builder, &class.name, true, true);
                         builder.action_with_stack_delta(
                             Action::ImplementsOp,
                             -2 - class.implements.len() as i32,
@@ -194,7 +210,7 @@ pub fn class_to_actions(class: &Class) -> Actions {
                     // Make the prototype not enumerable
                     builder.push(1);
                     builder.push(PushValue::Null);
-                    get_type_path(builder, &class.name, false);
+                    get_type_path(builder, &class.name, false, true);
                     builder.push("prototype");
                     builder.action(Action::GetMember);
                     builder.push(3);
@@ -206,7 +222,12 @@ pub fn class_to_actions(class: &Class) -> Actions {
     })
 }
 
-fn get_type_path(builder: &mut CodeBuilder, type_name: &str, from_global: bool) {
+fn get_type_path(
+    builder: &mut CodeBuilder,
+    type_name: &str,
+    from_global: bool,
+    and_get_value: bool,
+) {
     let segments: Vec<&str> = type_name.split(".").collect();
     let mut first = true;
     if from_global {
@@ -217,9 +238,11 @@ fn get_type_path(builder: &mut CodeBuilder, type_name: &str, from_global: bool) 
     for segment in segments {
         builder.push(segment);
         if first {
-            builder.action(Action::GetVariable);
+            if and_get_value {
+                builder.action(Action::GetVariable);
+            }
             first = false;
-        } else {
+        } else if and_get_value {
             builder.action(Action::GetMember);
         }
     }

--- a/crates/rascal/src/internal/definitions.rs
+++ b/crates/rascal/src/internal/definitions.rs
@@ -1,0 +1,93 @@
+use crate::Program;
+use crate::internal::as2::hir::Class;
+use indexmap::IndexMap;
+use std::collections::HashMap;
+
+pub struct FieldDefinition {
+    pub name: String,
+    pub type_name: Option<String>,
+    pub is_virtual: bool,
+}
+
+pub struct ClassDefinition {
+    pub extends: Option<String>,
+    pub fields: HashMap<String, FieldDefinition>,
+}
+
+impl From<&Class> for ClassDefinition {
+    fn from(value: &Class) -> Self {
+        let mut fields = HashMap::new();
+        for (field_name, field) in value.fields.iter() {
+            fields.insert(
+                field_name.clone(),
+                FieldDefinition {
+                    name: field_name.clone(),
+                    type_name: field.type_name.clone().map(|v| v.value),
+                    is_virtual: false,
+                },
+            );
+        }
+        for (field_name, _field) in value.virtual_properties.iter() {
+            fields.insert(
+                field_name.clone(),
+                FieldDefinition {
+                    name: field_name.clone(),
+                    type_name: None,
+                    is_virtual: true,
+                },
+            );
+        }
+        ClassDefinition {
+            extends: value.extends.clone(),
+            fields,
+        }
+    }
+}
+
+pub enum TypeDefinition {
+    Class(ClassDefinition),
+}
+
+pub struct ProgramDefinition {
+    pub types: IndexMap<String, TypeDefinition>,
+}
+
+impl From<&Program> for ProgramDefinition {
+    fn from(program: &Program) -> Self {
+        let mut result = Self {
+            types: Default::default(),
+        };
+
+        for class_def in &program.classes {
+            result.types.insert(
+                class_def.name.clone(),
+                TypeDefinition::Class(ClassDefinition::from(class_def)),
+            );
+        }
+
+        result
+    }
+}
+
+impl ProgramDefinition {
+    pub fn get_field<'a>(
+        &'a self,
+        type_name: &str,
+        field_name: &str,
+    ) -> Option<&'a FieldDefinition> {
+        let mut current_type = Some(type_name);
+        while let Some(type_name) = current_type {
+            if let Some(type_def) = self.types.get(type_name)
+                && let TypeDefinition::Class(class_def) = type_def
+            {
+                if let Some(field) = class_def.fields.get(field_name) {
+                    return Some(field);
+                }
+                current_type = class_def.extends.as_deref();
+                continue;
+            }
+            current_type = None;
+        }
+        None
+    }
+}

--- a/crates/rascal/src/program.rs
+++ b/crates/rascal/src/program.rs
@@ -225,7 +225,7 @@ impl<P: SourceProvider> ProgramBuilder<P> {
         let mut interfaces = vec![];
         let mut classes = vec![];
         let mut errors = ErrorSet::new();
-        let mut loaded_classes = IndexSet::new();
+        let mut loaded_classes = self.classes.iter().cloned().collect();
         let mut pending_classes = self.classes;
         let mut custom_pcodes = vec![];
         let known_script_paths = self.scripts.iter().cloned().collect();

--- a/crates/rascal/src/program.rs
+++ b/crates/rascal/src/program.rs
@@ -98,26 +98,26 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn compile(&self) -> CompiledProgram {
+    pub fn compile(self) -> CompiledProgram {
         let initializer = if self.initial_script.is_empty() {
             None
         } else {
             Some(script_to_actions(&self.initial_script))
         };
         let mut extra_modules = vec![];
-        for interface in self.interfaces.iter().rev() {
-            let actions = interface_to_actions(interface);
-            extra_modules.push((interface.name.to_owned(), actions));
+        for interface in self.interfaces.into_iter().rev() {
+            let actions = interface_to_actions(&interface);
+            extra_modules.push((interface.name, actions));
         }
-        for class in self.classes.iter().rev() {
-            let actions = class_to_actions(class);
-            extra_modules.push((class.name.to_owned(), actions));
+        for class in self.classes.into_iter().rev() {
+            let actions = class_to_actions(&class);
+            extra_modules.push((class.name, actions));
         }
         CompiledProgram {
             initializer,
             extra_modules,
-            compile_options: self.compile_options.clone(),
-            custom_pcodes: self.custom_pcodes.clone(),
+            compile_options: self.compile_options,
+            custom_pcodes: self.custom_pcodes,
         }
     }
 }

--- a/crates/rascal/src/program.rs
+++ b/crates/rascal/src/program.rs
@@ -123,7 +123,7 @@ impl Program {
             extra_modules.push((interface.name, actions));
         }
         for class in self.classes.into_iter().rev() {
-            let actions = class_to_actions(&class);
+            let actions = class_to_actions(&self.compile_options, &class);
             extra_modules.push((class.name, actions));
         }
         CompiledProgram {

--- a/crates/rascal/src/program.rs
+++ b/crates/rascal/src/program.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, ErrorSet};
 use crate::internal::as2::hir::constant_folder::fold_constants;
+use crate::internal::as2::hir::optimize_virtual_properties::optimize_virtual_properties;
 use crate::internal::as2::hir::register_promoter::promote_variables_to_registers;
 use crate::internal::as2::hir::scope::Scope;
 use crate::internal::as2::lexer::Lexer;
@@ -98,6 +99,18 @@ pub struct Program {
 }
 
 impl Program {
+    pub(crate) fn optimize(&mut self) {
+        optimize_virtual_properties(self);
+        if self
+            .compile_options
+            .optimizations
+            .promote_variables_to_registers
+            && self.compile_options.swf_version >= 7
+        {
+            promote_variables_to_registers(self);
+        }
+    }
+
     pub fn compile(self) -> CompiledProgram {
         let initializer = if self.initial_script.is_empty() {
             None
@@ -241,7 +254,7 @@ impl<P: SourceProvider> ProgramBuilder<P> {
             is_script: bool,
             optimizations: &OptimizationOptions,
             known_script_paths: &IndexSet<String>,
-            compile_options: &CompileOptions,
+            _compile_options: &CompileOptions,
         ) -> Option<hir::Document> {
             let source = match provider.load(path) {
                 Ok(source) => source,
@@ -272,9 +285,6 @@ impl<P: SourceProvider> ProgramBuilder<P> {
                 while fold_constants(&mut hir) {
                     // Keep going until nothing changed
                 }
-            }
-            if optimizations.promote_variables_to_registers && compile_options.swf_version >= 7 {
-                promote_variables_to_registers(&mut hir);
             }
             Some(hir)
         }
@@ -370,13 +380,15 @@ impl<P: SourceProvider> ProgramBuilder<P> {
 
         errors.error_unless_empty()?;
 
-        Ok(Program {
+        let mut program = Program {
             initial_script,
             interfaces,
             classes,
             custom_pcodes,
             compile_options: self.compile_options,
-        })
+        };
+        program.optimize();
+        Ok(program)
     }
 }
 

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@ClassMembersTest.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@ClassMembersTest.as.snap
@@ -85,21 +85,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -201,24 +211,35 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 name:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - ClassMembersTest
               could_reference_anything: false
@@ -272,21 +293,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - ClassMembersTest
               could_reference_anything: false
@@ -328,21 +359,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - "null"
               could_reference_anything: false
@@ -373,21 +414,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -417,21 +468,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -468,21 +529,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -519,21 +590,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -615,24 +696,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 value:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 3
@@ -714,24 +806,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 value:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 3
@@ -768,21 +871,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -864,24 +977,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 value:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 3
@@ -963,24 +1087,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 value:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 3
@@ -1017,21 +1152,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -1195,27 +1340,43 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: ClassMembersTest
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 x:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 y:
                   used: true
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 1789
+                      end: 1805
+                    value: ClassMembersTest
               referenced_variables:
                 - ClassMembersTest
               could_reference_anything: false
@@ -1525,24 +1686,35 @@ Ok:
             this:
               used: true
               used_in_inner_scope: false
+              type_name:
+                span:
+                  start: 0
+                  end: 0
+                value: ClassMembersTest
             arguments:
               used: false
               used_in_inner_scope: false
+              type_name: ~
             super:
               used: false
               used_in_inner_scope: false
+              type_name: ~
             _root:
               used: false
               used_in_inner_scope: false
+              type_name: ~
             _parent:
               used: false
               used_in_inner_scope: false
+              type_name: ~
             _global:
               used: false
               used_in_inner_scope: false
+              type_name: ~
             name:
               used: false
               used_in_inner_scope: false
+              type_name: ~
           referenced_variables:
             - path
           could_reference_anything: false
@@ -1617,21 +1789,35 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: path.to.ANestedClass
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 35
+                      end: 59
+                    value: path.to.ANestedBaseClass
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - path
               could_reference_anything: false
@@ -1707,21 +1893,35 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: path.to.ANestedClass
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 35
+                      end: 59
+                    value: path.to.ANestedBaseClass
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - path
               could_reference_anything: false

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@ClassMembersTest.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@ClassMembersTest.as.snap
@@ -1287,11 +1287,11 @@ Ok:
                     start: 1820
                     end: 1844
                   value:
-                    BinaryOperator:
-                      - Assign
-                      - span:
+                    Call:
+                      name:
+                        span:
                           start: 1820
-                          end: 1836
+                          end: 1844
                         value:
                           Field:
                             - span:
@@ -1301,17 +1301,18 @@ Ok:
                                 Constant:
                                   Register: 2
                             - span:
-                                start: 1821
-                                end: 1836
+                                start: 1820
+                                end: 1844
                               value:
                                 Constant:
-                                  String: virtualProperty
-                      - span:
-                          start: 1839
-                          end: 1844
-                        value:
-                          Constant:
-                            String: foo
+                                  String: __set__virtualProperty
+                      args:
+                        - span:
+                            start: 1839
+                            end: 1844
+                          value:
+                            Constant:
+                              String: foo
               - Expr:
                   span:
                     start: 1854
@@ -1322,19 +1323,26 @@ Ok:
                         start: 1861
                         end: 1877
                       value:
-                        Field:
-                          - span:
-                              start: 1860
-                              end: 1861
-                            value:
-                              Constant:
-                                Register: 2
-                          - span:
-                              start: 1862
+                        Call:
+                          name:
+                            span:
+                              start: 1861
                               end: 1877
                             value:
-                              Constant:
-                                String: virtualProperty
+                              Field:
+                                - span:
+                                    start: 1860
+                                    end: 1861
+                                  value:
+                                    Constant:
+                                      Register: 2
+                                - span:
+                                    start: 1861
+                                    end: 1877
+                                  value:
+                                    Constant:
+                                      String: __get__virtualProperty
+                          args: []
             scope:
               defined_variables:
                 this:
@@ -1633,11 +1641,11 @@ Ok:
                 start: 556
                 end: 583
               value:
-                BinaryOperator:
-                  - Assign
-                  - span:
+                Call:
+                  name:
+                    span:
                       start: 556
-                      end: 571
+                      end: 583
                     value:
                       Field:
                         - span:
@@ -1648,16 +1656,17 @@ Ok:
                               Register: 1
                         - span:
                             start: 556
-                            end: 571
+                            end: 583
                           value:
                             Constant:
-                              String: virtualProperty
-                  - span:
-                      start: 574
-                      end: 583
-                    value:
-                      Constant:
-                        String: a value
+                              String: __set__virtualProperty
+                  args:
+                    - span:
+                        start: 574
+                        end: 583
+                      value:
+                        Constant:
+                          String: a value
           - Expr:
               span:
                 start: 593
@@ -1668,19 +1677,26 @@ Ok:
                     start: 599
                     end: 614
                   value:
-                    Field:
-                      - span:
+                    Call:
+                      name:
+                        span:
                           start: 599
                           end: 614
                         value:
-                          Constant:
-                            Register: 1
-                      - span:
-                          start: 599
-                          end: 614
-                        value:
-                          Constant:
-                            String: virtualProperty
+                          Field:
+                            - span:
+                                start: 599
+                                end: 614
+                              value:
+                                Constant:
+                                  Register: 1
+                            - span:
+                                start: 599
+                                end: 614
+                              value:
+                                Constant:
+                                  String: __get__virtualProperty
+                      args: []
         scope:
           defined_variables:
             this:

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@ClassMembersTest.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@ClassMembersTest.as.snap
@@ -4,7 +4,38 @@ expression: parsed
 input_file: samples/as2_classes/ClassMembersTest.as
 ---
 Ok:
-  initial_script: []
+  initial_script:
+    - Expr:
+        span:
+          start: 0
+          end: 0
+        value:
+          Call:
+            name:
+              span:
+                start: 0
+                end: 0
+              value:
+                Field:
+                  - span:
+                      start: 0
+                      end: 0
+                    value:
+                      Constant:
+                        Identifier: ClassMembersTest
+                  - span:
+                      start: 0
+                      end: 0
+                    value:
+                      Constant:
+                        String: main
+            args:
+              - span:
+                  start: 0
+                  end: 0
+                value:
+                  Constant:
+                    Identifier: this
   interfaces:
     - name: AnEmptyInterface
       extends: ~
@@ -1004,6 +1035,191 @@ Ok:
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
+            preload_this: false
+            suppress_this: true
+            preload_arguments: false
+            suppress_arguments: true
+            preload_super: false
+            suppress_super: true
+            preload_root: false
+            preload_parent: false
+            preload_global: false
+          is_static: true
+        main:
+          function:
+            signature:
+              name:
+                span:
+                  start: 1688
+                  end: 1692
+                value: main
+              args: []
+              return_type: ~
+            body:
+              - Expr:
+                  span:
+                    start: 0
+                    end: 0
+                  value:
+                    BinaryOperator:
+                      - Assign
+                      - span:
+                          start: 0
+                          end: 0
+                        value:
+                          Constant:
+                            Register: 1
+                      - span:
+                          start: 1713
+                          end: 1736
+                        value:
+                          New:
+                            name:
+                              span:
+                                start: 1717
+                                end: 1733
+                              value:
+                                Constant:
+                                  Identifier: ClassMembersTest
+                            args:
+                              - span:
+                                  start: 1734
+                                  end: 1736
+                                value:
+                                  Constant:
+                                    String: ""
+              - Expr:
+                  span:
+                    start: 1748
+                    end: 1772
+                  value:
+                    BinaryOperator:
+                      - Assign
+                      - span:
+                          start: 1748
+                          end: 1764
+                        value:
+                          Field:
+                            - span:
+                                start: 1747
+                                end: 1748
+                              value:
+                                Constant:
+                                  Register: 1
+                            - span:
+                                start: 1749
+                                end: 1764
+                              value:
+                                Constant:
+                                  String: virtualProperty
+                      - span:
+                          start: 1767
+                          end: 1772
+                        value:
+                          Constant:
+                            String: foo
+              - Expr:
+                  span:
+                    start: 0
+                    end: 0
+                  value:
+                    BinaryOperator:
+                      - Assign
+                      - span:
+                          start: 0
+                          end: 0
+                        value:
+                          Constant:
+                            Register: 2
+                      - span:
+                          start: 1808
+                          end: 1809
+                        value:
+                          Constant:
+                            Register: 1
+              - Expr:
+                  span:
+                    start: 1820
+                    end: 1844
+                  value:
+                    BinaryOperator:
+                      - Assign
+                      - span:
+                          start: 1820
+                          end: 1836
+                        value:
+                          Field:
+                            - span:
+                                start: 1819
+                                end: 1820
+                              value:
+                                Constant:
+                                  Register: 2
+                            - span:
+                                start: 1821
+                                end: 1836
+                              value:
+                                Constant:
+                                  String: virtualProperty
+                      - span:
+                          start: 1839
+                          end: 1844
+                        value:
+                          Constant:
+                            String: foo
+              - Expr:
+                  span:
+                    start: 1854
+                    end: 1878
+                  value:
+                    Trace:
+                      span:
+                        start: 1861
+                        end: 1877
+                      value:
+                        Field:
+                          - span:
+                              start: 1860
+                              end: 1861
+                            value:
+                              Constant:
+                                Register: 2
+                          - span:
+                              start: 1862
+                              end: 1877
+                            value:
+                              Constant:
+                                String: virtualProperty
+            scope:
+              defined_variables:
+                this:
+                  used: false
+                  used_in_inner_scope: false
+                arguments:
+                  used: false
+                  used_in_inner_scope: false
+                super:
+                  used: false
+                  used_in_inner_scope: false
+                _root:
+                  used: false
+                  used_in_inner_scope: false
+                _parent:
+                  used: false
+                  used_in_inner_scope: false
+                _global:
+                  used: false
+                  used_in_inner_scope: false
+                x:
+                  used: true
+                  used_in_inner_scope: false
+                y:
+                  used: true
+                  used_in_inner_scope: false
+              referenced_variables:
+                - ClassMembersTest
+              could_reference_anything: false
+            register_count: 3
             preload_this: false
             suppress_this: true
             preload_arguments: false

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@MtascStyle.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@MtascStyle.as.snap
@@ -181,21 +181,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: MtascStyle
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - AnEmptyInterface
                 - foo

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@NotMtascStyle.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@NotMtascStyle.as.snap
@@ -39,21 +39,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 0
+                      end: 0
+                    value: NotMtascStyle
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@function.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@function.as.snap
@@ -44,21 +44,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -159,27 +165,35 @@ Ok:
                   this:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   arguments:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   super:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _root:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _parent:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _global:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   a:
                     used: true
                     used_in_inner_scope: false
+                    type_name: ~
                   b:
                     used: true
                     used_in_inner_scope: false
+                    type_name: ~
                 referenced_variables: []
                 could_reference_anything: false
               register_count: 3
@@ -273,21 +287,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@function_hoisting.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@function_hoisting.as.snap
@@ -168,21 +168,27 @@ Ok:
                           this:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           arguments:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           super:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _root:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _parent:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _global:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                         referenced_variables: []
                         could_reference_anything: false
                       register_count: 1
@@ -200,21 +206,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - functionWithinAFunction
                 - firstVar
@@ -352,21 +364,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - firstVar
                 - secondVar
@@ -489,21 +507,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - firstVar
                 - secondVar
@@ -592,21 +616,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -665,21 +695,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@function_in_loop_break_continue.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@function_in_loop_break_continue.as.snap
@@ -173,24 +173,31 @@ Ok:
                           this:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           arguments:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           super:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _root:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _parent:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _global:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           v:
                             used: true
                             used_in_inner_scope: false
+                            type_name: ~
                         referenced_variables: []
                         could_reference_anything: false
                       register_count: 2
@@ -227,21 +234,27 @@ Ok:
                           this:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           arguments:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           super:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _root:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _parent:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _global:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                         referenced_variables: []
                         could_reference_anything: false
                       register_count: 1

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@import_affects_functions.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@import_affects_functions.as.snap
@@ -37,21 +37,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - BitmapData
               could_reference_anything: false
@@ -120,21 +126,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - flash
               could_reference_anything: false

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@inline_pcode.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@inline_pcode.as.snap
@@ -53,24 +53,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 message:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@nested_break_continue.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@nested_break_continue.as.snap
@@ -168,21 +168,27 @@ Ok:
                                   this:
                                     used: false
                                     used_in_inner_scope: false
+                                    type_name: ~
                                   arguments:
                                     used: false
                                     used_in_inner_scope: false
+                                    type_name: ~
                                   super:
                                     used: false
                                     used_in_inner_scope: false
+                                    type_name: ~
                                   _root:
                                     used: false
                                     used_in_inner_scope: false
+                                    type_name: ~
                                   _parent:
                                     used: false
                                     used_in_inner_scope: false
+                                    type_name: ~
                                   _global:
                                     used: false
                                     used_in_inner_scope: false
+                                    type_name: ~
                                 referenced_variables: []
                                 could_reference_anything: false
                               register_count: 1

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@op_precedence__inc_dec.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@op_precedence__inc_dec.as.snap
@@ -56,24 +56,31 @@ Ok:
                   this:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   arguments:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   super:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _root:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _parent:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _global:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   msg:
                     used: true
                     used_in_inner_scope: false
+                    type_name: ~
                 referenced_variables: []
                 could_reference_anything: false
               register_count: 2

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@registers.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@registers.as.snap
@@ -111,27 +111,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 8
@@ -262,27 +270,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: true
             register_count: 0
@@ -318,30 +334,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 2
@@ -402,30 +427,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: true
             register_count: 0

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regressions__ruffle_avm1_edittext_drag_select.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regressions__ruffle_avm1_edittext_drag_select.as.snap
@@ -135,21 +135,27 @@ Ok:
                       this:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       arguments:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       super:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       _root:
                         used: true
                         used_in_inner_scope: false
+                        type_name: ~
                       _parent:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       _global:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                     referenced_variables: []
                     could_reference_anything: false
                   register_count: 2
@@ -433,21 +439,27 @@ Ok:
                       this:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       arguments:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       super:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       _root:
                         used: true
                         used_in_inner_scope: false
+                        type_name: ~
                       _parent:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                       _global:
                         used: false
                         used_in_inner_scope: false
+                        type_name: ~
                     referenced_variables:
                       - text
                     could_reference_anything: false

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regressions__ruffle_avm1_mouse_pos.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regressions__ruffle_avm1_mouse_pos.as.snap
@@ -491,30 +491,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 clips:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 i:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 clip:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - _xmouse
                 - oldX
@@ -572,21 +581,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - dump
               could_reference_anything: false

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regressions__ruffle_avm1_movieclip_lockroot.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regressions__ruffle_avm1_movieclip_lockroot.as.snap
@@ -462,27 +462,35 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 value:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 valueLabel:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -897,21 +905,27 @@ Ok:
                 this:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - testSet
                 - undefined
@@ -1219,21 +1233,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - createEmptyMovieClip
                 - levels
@@ -2393,21 +2413,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - levels
               could_reference_anything: false
@@ -3185,21 +3211,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 2
@@ -3260,21 +3292,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - testSelf
                 - testChildren

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regular_imports.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@regular_imports.as.snap
@@ -345,21 +345,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - flash
               could_reference_anything: false

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@scoping.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@scoping.as.snap
@@ -117,30 +117,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -275,30 +284,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -434,30 +452,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -638,33 +665,43 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 i:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 5
@@ -835,33 +872,43 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 i:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 5
@@ -1004,30 +1051,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -1169,30 +1225,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -1359,30 +1424,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -1516,24 +1590,31 @@ Ok:
                           this:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           arguments:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           super:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _root:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _parent:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _global:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           b:
                             used: true
                             used_in_inner_scope: false
+                            type_name: ~
                         referenced_variables:
                           - a
                         could_reference_anything: false
@@ -1566,30 +1647,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: true
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables:
                 - inner
               could_reference_anything: false
@@ -1753,36 +1843,47 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 c:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 obj:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 k:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 6
@@ -1857,21 +1958,27 @@ Ok:
                           this:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           arguments:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           super:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _root:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _parent:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _global:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                         referenced_variables:
                           - a
                         could_reference_anything: true
@@ -1904,24 +2011,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: true
+                  type_name: ~
               referenced_variables:
                 - inner
               could_reference_anything: true
@@ -1986,21 +2100,27 @@ Ok:
                           this:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           arguments:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           super:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _root:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _parent:
                             used: false
                             used_in_inner_scope: false
+                            type_name: ~
                           _global:
                             used: true
                             used_in_inner_scope: false
+                            type_name: ~
                         referenced_variables: []
                         could_reference_anything: true
                       register_count: 0
@@ -2018,24 +2138,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: true
             register_count: 0

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@try_catch_stack.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@try_catch_stack.as.snap
@@ -34,21 +34,27 @@ Ok:
                   this:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   arguments:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   super:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _root:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _parent:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _global:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                 referenced_variables: []
                 could_reference_anything: false
               register_count: 1
@@ -164,21 +170,27 @@ Ok:
                   this:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   arguments:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   super:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _root:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _parent:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                   _global:
                     used: false
                     used_in_inner_scope: false
+                    type_name: ~
                 referenced_variables:
                   - bad
                   - e

--- a/crates/rascal/src/snapshots/rascal__program__tests__all_samples@typed_variables.as.snap
+++ b/crates/rascal/src/snapshots/rascal__program__tests__all_samples@typed_variables.as.snap
@@ -150,27 +150,35 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 a:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 b:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 3
@@ -214,21 +222,27 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 1
@@ -284,24 +298,31 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 data:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 2
@@ -510,30 +531,39 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 name:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 age:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 isValid:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
               referenced_variables: []
               could_reference_anything: false
             register_count: 4
@@ -774,30 +804,43 @@ Ok:
                 this:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arguments:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 super:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _root:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _parent:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 _global:
                   used: false
                   used_in_inner_scope: false
+                  type_name: ~
                 arr:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 callback:
                   used: true
                   used_in_inner_scope: false
+                  type_name: ~
                 i:
                   used: true
                   used_in_inner_scope: false
+                  type_name:
+                    span:
+                      start: 781
+                      end: 787
+                    value: Number
               referenced_variables: []
               could_reference_anything: false
             register_count: 4

--- a/crates/rascal/src/snapshots/rascal__tests__all_samples@ClassMembersTest.as.snap
+++ b/crates/rascal/src/snapshots/rascal__tests__all_samples@ClassMembersTest.as.snap
@@ -3,7 +3,24 @@ source: crates/rascal/src/tests.rs
 expression: result
 input_file: samples/as2_classes/ClassMembersTest.as
 ---
-initializer: ~
+initializer:
+  actions:
+    - ConstantPool:
+        - this
+        - ClassMembersTest
+        - main
+    - Push:
+        - Constant: 0
+    - GetVariable
+    - Push:
+        - Integer: 1
+        - Constant: 1
+    - GetVariable
+    - Push:
+        - Constant: 2
+    - CallMethod
+    - Pop
+  label_positions: {}
 extra_modules:
   - - path.to.ANestedInterface
     - actions:
@@ -466,6 +483,8 @@ extra_modules:
             - Static!
             - __get__virtualPropertyProbablyStatic
             - __get__virtualPropertyProbablyNotStatic
+            - ""
+            - foo
             - BitmapData on class!
             - Ahhh!
         - Push:
@@ -855,6 +874,52 @@ extra_modules:
               label_positions: {}
         - SetMember
         - Push:
+            - Register: 1
+            - String: main
+        - DefineFunction2:
+            name: ""
+            params: []
+            actions:
+              actions:
+                - Push:
+                    - Constant: 27
+                    - Integer: 1
+                    - Constant: 15
+                - NewObject
+                - StoreRegister: 1
+                - Pop
+                - Push:
+                    - Register: 1
+                    - Constant: 10
+                    - Constant: 28
+                - SetMember
+                - Push:
+                    - Register: 1
+                - StoreRegister: 2
+                - Pop
+                - Push:
+                    - Register: 2
+                    - Constant: 10
+                    - Constant: 28
+                - SetMember
+                - Push:
+                    - Register: 2
+                    - Constant: 10
+                - GetMember
+                - Trace
+              label_positions: {}
+            register_count: 3
+            preload_this: false
+            suppress_this: true
+            preload_arguments: false
+            suppress_arguments: true
+            preload_super: false
+            suppress_super: true
+            preload_root: false
+            preload_parent: false
+            preload_global: false
+        - SetMember
+        - Push:
             - Register: 2
             - String: regularPropertySetToFive
             - Integer: 5
@@ -862,12 +927,12 @@ extra_modules:
         - Push:
             - Register: 2
             - String: BitmapData
-            - Constant: 27
+            - Constant: 29
         - SetMember
         - Push:
             - Register: 1
             - String: scream
-            - Constant: 28
+            - Constant: 30
         - SetMember
         - Push:
             - Register: 2
@@ -957,7 +1022,7 @@ extra_modules:
         - CallFunction
         - Pop
       label_positions:
-        loc0000: 109
+        loc0000: 112
 compile_options:
   swf_version: 15
   optimizations:

--- a/crates/rascal/src/snapshots/rascal__tests__all_samples@ClassMembersTest.as.snap
+++ b/crates/rascal/src/snapshots/rascal__tests__all_samples@ClassMembersTest.as.snap
@@ -466,8 +466,9 @@ extra_modules:
             - ANestedClass
             - create
             - success
-            - virtualProperty
             - a value
+            - __set__virtualProperty
+            - __get__virtualProperty
             - test!
             - "Hey, "
             - "!"
@@ -479,11 +480,11 @@ extra_modules:
             - "New value: "
             - __get__onlySetter
             - "Virtually setting to "
-            - __get__virtualProperty
             - Static!
             - __get__virtualPropertyProbablyStatic
             - __get__virtualPropertyProbablyNotStatic
             - ""
+            - virtualProperty
             - foo
             - BitmapData on class!
             - Ahhh!
@@ -546,14 +547,17 @@ extra_modules:
                 - CallMethod
                 - Trace
                 - Push:
-                    - Register: 1
                     - Constant: 10
+                    - Integer: 1
+                    - Register: 1
                     - Constant: 11
-                - SetMember
+                - CallMethod
+                - Pop
                 - Push:
+                    - Integer: 0
                     - Register: 1
-                    - Constant: 10
-                - GetMember
+                    - Constant: 12
+                - CallMethod
                 - Trace
               label_positions: {}
             register_count: 2
@@ -597,7 +601,7 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 12
+                    - Constant: 13
                 - Trace
               label_positions: {}
         - SetMember
@@ -612,19 +616,19 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 13
+                    - Constant: 14
                     - Register: 1
                 - Add2
                 - Push:
-                    - Constant: 14
+                    - Constant: 15
                 - Add2
                 - Trace
                 - Push:
                     - Integer: 0
-                    - Constant: 15
+                    - Constant: 16
                 - GetVariable
                 - Push:
-                    - Constant: 16
+                    - Constant: 17
                 - CallMethod
                 - Pop
               label_positions: {}
@@ -648,10 +652,10 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 15
+                    - Constant: 16
                 - GetVariable
                 - Push:
-                    - Constant: 17
+                    - Constant: 18
                 - GetMember
                 - Trace
               label_positions: {}
@@ -698,7 +702,7 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 18
+                    - Constant: 19
                 - Return
               label_positions: {}
         - SetMember
@@ -711,7 +715,7 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 19
+                    - Constant: 20
                 - Return
               label_positions: {}
         - SetMember
@@ -726,14 +730,14 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 20
+                    - Constant: 21
                     - Register: 2
                 - Add2
                 - Trace
                 - Push:
                     - Integer: 0
                     - Register: 1
-                    - Constant: 21
+                    - Constant: 22
                 - CallMethod
                 - Return
               label_positions: {}
@@ -759,14 +763,14 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 22
+                    - Constant: 23
                     - Register: 2
                 - Add2
                 - Trace
                 - Push:
                     - Integer: 0
                     - Register: 1
-                    - Constant: 23
+                    - Constant: 12
                 - CallMethod
                 - Return
               label_positions: {}
@@ -805,7 +809,7 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 20
+                    - Constant: 21
                     - Register: 2
                 - Add2
                 - Trace
@@ -838,7 +842,7 @@ extra_modules:
             actions:
               actions:
                 - Push:
-                    - Constant: 20
+                    - Constant: 21
                     - Register: 2
                 - Add2
                 - Trace
@@ -884,28 +888,31 @@ extra_modules:
                 - Push:
                     - Constant: 27
                     - Integer: 1
-                    - Constant: 15
+                    - Constant: 16
                 - NewObject
                 - StoreRegister: 1
                 - Pop
                 - Push:
                     - Register: 1
-                    - Constant: 10
                     - Constant: 28
+                    - Constant: 29
                 - SetMember
                 - Push:
                     - Register: 1
                 - StoreRegister: 2
                 - Pop
                 - Push:
+                    - Constant: 29
+                    - Integer: 1
                     - Register: 2
-                    - Constant: 10
-                    - Constant: 28
-                - SetMember
+                    - Constant: 11
+                - CallMethod
+                - Pop
                 - Push:
+                    - Integer: 0
                     - Register: 2
-                    - Constant: 10
-                - GetMember
+                    - Constant: 12
+                - CallMethod
                 - Trace
               label_positions: {}
             register_count: 3
@@ -927,12 +934,12 @@ extra_modules:
         - Push:
             - Register: 2
             - String: BitmapData
-            - Constant: 29
+            - Constant: 30
         - SetMember
         - Push:
             - Register: 1
             - String: scream
-            - Constant: 30
+            - Constant: 31
         - SetMember
         - Push:
             - Register: 2

--- a/samples/as2_classes/ClassMembersTest.as
+++ b/samples/as2_classes/ClassMembersTest.as
@@ -70,4 +70,12 @@ class ClassMembersTest implements AnEmptyInterface {
     static function get virtualPropertyProbablyNotStatic() {
         return "Static!";
     }
+
+    static function main() {
+        var x = new ClassMembersTest("");
+        x.virtualProperty = "foo";
+        var y: ClassMembersTest = x;
+        y.virtualProperty = "foo";
+        trace(y.virtualProperty);
+    }
 }


### PR DESCRIPTION
Virtual properties are "optimized" to instead use the direct functions (e.g. `foo.bar` turns into `foo.__get__bar()`), and don't use Extends below swf 7